### PR TITLE
feature: Updates config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,10 @@ workflows:
   version: 2
   build:
     jobs:
-      - build
+      - build:
+          filters:
+            branches:
+              ignore: gh-pages
       - deploy:
           requires:
             - build


### PR DESCRIPTION
Updates config.yml so that circleCI builds do not run on our deployment commits to `gh-pages`

example commit can be found here: https://github.com/CityOfZion/neo-3-preview/commit/b49ae0adad56c410c1c386356e1d66887a028677