### PR TITLE
feature: Sets up cache busting for stats data

### DIFF
--- a/src/actions/statsActions.js
+++ b/src/actions/statsActions.js
@@ -1,3 +1,5 @@
+import { isEmpty } from 'lodash-es'
+
 import { GENERATE_BASE_URL } from '../constants'
 import { convertMillisecondsToSeconds } from '../utils/time'
 
@@ -31,13 +33,11 @@ export const requestStatsError = error => dispatch => {
 
 export function shouldFetchStats(state, index) {
   const data = state.stats.stats
-
-  if (!data) {
+  if (isEmpty(data) && !state.stats.isLoading) {
     return true
   } else if (state.stats.isLoading) {
     return false
   }
-
   if (state.stats.lastUpdated) {
     const currSeconds = convertMillisecondsToSeconds(Date.now())
     const lastUpdateSeconds = convertMillisecondsToSeconds(

--- a/src/actions/statsActions.js
+++ b/src/actions/statsActions.js
@@ -1,4 +1,7 @@
 import { GENERATE_BASE_URL } from '../constants'
+import { convertMillisecondsToSeconds } from '../utils/time'
+
+const STATS_CACHE_LENGTH_IN_SECONDS = 120
 
 export const REQUEST_STATS = 'REQUEST_STATS'
 export const requestStats = indexOrHash => dispatch => {
@@ -28,11 +31,25 @@ export const requestStatsError = error => dispatch => {
 
 export function shouldFetchStats(state, index) {
   const data = state.stats.stats
+
   if (!data) {
     return true
   } else if (state.stats.isLoading) {
     return false
   }
+
+  if (state.stats.lastUpdated) {
+    const currSeconds = convertMillisecondsToSeconds(Date.now())
+    const lastUpdateSeconds = convertMillisecondsToSeconds(
+      state.stats.lastUpdated,
+    )
+    const diffInSeconds = currSeconds - lastUpdateSeconds
+
+    if (diffInSeconds > STATS_CACHE_LENGTH_IN_SECONDS) {
+      return true
+    }
+  }
+
   return false
 }
 

--- a/src/hoc/withStatsData.js
+++ b/src/hoc/withStatsData.js
@@ -15,15 +15,10 @@ export default function withStatsData(WrappedComponent) {
   return connect(
     mapStateToProps,
     mapDispatchToProps,
-  )(
-    class extends React.Component {
-      componentDidMount() {
-        this.props.fetchStats()
-      }
-
-      render() {
-        return <WrappedComponent {...this.props} />
-      }
-    },
-  )
+  )(props => {
+    React.useEffect(() => {
+      props.fetchStats()
+    })
+    return <WrappedComponent {...props} />
+  })
 }

--- a/src/reducers/statsReducer.js
+++ b/src/reducers/statsReducer.js
@@ -16,6 +16,7 @@ export default (
       return Object.assign({}, state, {
         isLoading: false,
         stats: action.json,
+        lastUpdated: action.receivedAt,
       })
     default:
       return state

--- a/src/utils/time.js
+++ b/src/utils/time.js
@@ -5,3 +5,5 @@ export const convertMilliseconds = ms => {
 }
 
 export const formatTime = time => moment(time).format('MM-DD-YYYY | HH:mm:ss')
+
+export const convertMillisecondsToSeconds = millis => Math.floor(millis / 1000)


### PR DESCRIPTION
Although an issue was never opened @deanragnarok mentioned that he noticed the stats data was only being fetched once when the app loaded and then never again. This PR makes it so that after 2 minutes if the home page is opened again the cache is reset by fresh data from `/stats`