### PR TITLE
fix parsing of transfer addresses

### DIFF
--- a/src/containers/transaction/Transaction.js
+++ b/src/containers/transaction/Transaction.js
@@ -33,11 +33,11 @@ const generateTransfersArr = async transaction => {
             value => value.type === 'Integer',
           ).value
           const from_address = await NeoConvertor.Address.scriptHashToAddress(
-            notification.state.value[2].value,
+            notification.state.value[1].value,
             true,
           )
           const to_address = await NeoConvertor.Address.scriptHashToAddress(
-            notification.state.value[1].value,
+            notification.state.value[2].value,
             true,
           )
           transfers.push({

--- a/src/containers/transaction/Transaction.js
+++ b/src/containers/transaction/Transaction.js
@@ -32,15 +32,19 @@ const generateTransfersArr = async transaction => {
           const amount = notification.state.value.find(
             value => value.type === 'Integer',
           ).value
-          const address = await NeoConvertor.Address.scriptHashToAddress(
+          const from_address = await NeoConvertor.Address.scriptHashToAddress(
             notification.state.value[2].value,
+            true,
+          )
+          const to_address = await NeoConvertor.Address.scriptHashToAddress(
+            notification.state.value[1].value,
             true,
           )
           transfers.push({
             name: asset.name,
             amount: asset.name === 'NEO' ? amount : CONVERT_TO_DECIMAL(amount),
-            to: address,
-            from: transaction.sender,
+            to: to_address,
+            from: from_address,
           })
         }
       }


### PR DESCRIPTION
This transfer summary in the transaction page doesn't match the notification log:
 https://neo3-preview.com/transaction/0xbbc320ceb17c704987deb0db157a10248f983b06969467e51a6b960c9bc02efc 

The transfer is between two different addresses according to the notification log, but the transfer summary in the page shows as if the transfer was made from the sender address to itself. 

It's actually the *other* address transferring GAS to the sender address (both addresses were part of the same neo-cli wallet so I guess it used the default wallet address as the tx sender address even though the `Transfer` sender was different).